### PR TITLE
clean up: change usage of interface to []byte in mmr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,4 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
-require golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)
+require golang.org/x/crypto v0.0.0-20211202192323-5770296d904e

--- a/mmr/errors.go
+++ b/mmr/errors.go
@@ -4,8 +4,14 @@ import (
 	"errors"
 )
 
-// proof items is not enough to build a tree
+// ErrCorruptedProof is of the type error. It is returned when proof is considered corrupt
 var ErrCorruptedProof = errors.New("corrupted proof: proof items is not enough to build a tree")
+
+// ErrGenProofForInvalidLeaves is of the type error. It is returned when the list of leaves is empty or beyond mmr range
 var ErrGenProofForInvalidLeaves = errors.New("leaves is an empty list, or beyond the mmr range")
+
+// ErrInconsistentStore is of the type error. It is returned when the store is considered inconsistent
 var ErrInconsistentStore = errors.New("inconsistent store")
+
+// ErrGetRootOnEmpty is of the type error. It is returned when the MMR is empty
 var ErrGetRootOnEmpty = errors.New("get root on an empty MMR")

--- a/mmr/helper.go
+++ b/mmr/helper.go
@@ -10,11 +10,11 @@ func getPeakPosByHeight(height uint32) uint64 {
 }
 
 func leftPeakHeightPos(mmrSize uint64) (uint32, uint64) {
+	var prevPos uint64
 	var height uint32 = 1
-	var prevPos uint64 = 0
 	var pos = getPeakPosByHeight(height)
 	for pos < mmrSize {
-		height += 1
+		height++
 		prevPos = pos
 		pos = getPeakPosByHeight(height)
 	}
@@ -39,14 +39,14 @@ func getRightPeak(height uint32, pos, mmrSize uint64) *peak {
 		}
 		// move to left child
 		pos -= parentOffset(height - 1)
-		height -= 1
+		height--
 	}
 	return &peak{height, pos}
 }
 
-func getPeaks(mmrSize uint64) (pos_s []uint64) {
+func getPeaks(mmrSize uint64) (positions []uint64) {
 	var height, pos = leftPeakHeightPos(mmrSize)
-	pos_s = append(pos_s, pos)
+	positions = append(positions, pos)
 
 	for height > 0 {
 		p := getRightPeak(height, pos, mmrSize)
@@ -55,14 +55,14 @@ func getPeaks(mmrSize uint64) (pos_s []uint64) {
 		}
 		height = p.height
 		pos = p.pos
-		pos_s = append(pos_s, pos)
+		positions = append(positions, pos)
 	}
 
-	return pos_s
+	return positions
 }
 
 func posHeightInTree(pos uint64) uint32 {
-	pos += 1
+	pos++
 	allOnes := func(num uint64) bool { return num != 0 && zerosCount64(num) == bits.LeadingZeros64(num) }
 	jumpLeft := func(pos uint64) uint64 {
 		var bitLength = uint32(64 - bits.LeadingZeros64(pos))
@@ -81,11 +81,14 @@ func zerosCount64(num uint64) int {
 	return 64 - bits.OnesCount64(num)
 }
 
+// LeafIndexToPos returns the position of a leaf from its index.
 func LeafIndexToPos(index uint64) uint64 {
 	// mmr_size - H - 1, H is the height(intervals) of last peak
 	return LeafIndexToMMRSize(index) - uint64(bits.TrailingZeros64(index+1)) - 1
 }
 
+// LeafIndexToMMRSize returns the mmr size of an mmr tree provided the leaf index passed as an argument is the last leaf in
+// the tree.
 func LeafIndexToMMRSize(index uint64) uint64 {
 	// leaf index start with 0
 	var leavesCount = index + 1
@@ -95,7 +98,7 @@ func LeafIndexToMMRSize(index uint64) uint64 {
 	return 2*leavesCount - uint64(peakCount)
 }
 
-func pop(ph []interface{}) (interface{}, []interface{}) {
+func pop(ph [][]byte) ([]byte, [][]byte) {
 	if len(ph) == 0 {
 		return nil, ph[:]
 	}

--- a/mmr/iterator.go
+++ b/mmr/iterator.go
@@ -1,43 +1,40 @@
 package mmr
 
+// Iterator is a wrapper for a slice of bytes. It exposes helper methods for accessing about the slice and storing data
+// to it
 type Iterator struct {
-	Items []interface{}
+	Items [][]byte
 	index uint64
 }
 
+// NewIterator creates a new object of the Iterator
 func NewIterator() *Iterator {
 	return &Iterator{
-		Items: make([]interface{}, 0),
+		Items: make([][]byte, 0),
 	}
 }
 
-func (i *Iterator) push(item interface{}) {
+func (i *Iterator) push(item []byte) {
 	i.Items = append(i.Items, item)
-}
-
-func (i *Iterator) get(index int) interface{} {
-	return i.Items[index]
 }
 
 func (i *Iterator) length() int {
 	return len(i.Items)
 }
 
-func (i *Iterator) splitOff(index int) []interface{} {
+func (i *Iterator) splitOff(index int) [][]byte {
 	split := i.Items[index:]
 	i.Items = i.Items[:index]
 	return split
 }
 
-func (i *Iterator) next() interface{} {
+// Next returns the next item from the slice of items and increases the index. It returns nil when the last item in
+// the slice has already been returned.
+func (i *Iterator) Next() []byte {
 	if len(i.Items) > int(i.index) {
 		in := i.index
 		i.index++
 		return i.Items[in]
 	}
 	return nil
-}
-
-func (i *Iterator) isEmpty() bool {
-	return len(i.Items) == 0
 }

--- a/mmr/iterator_test.go
+++ b/mmr/iterator_test.go
@@ -1,38 +1,41 @@
-package mmr
+package mmr_test
 
 import (
+	"reflect"
 	"testing"
+
+	merklego_mmr "github.com/ComposableFi/merkle-go/mmr"
 )
 
 func TestNext(t *testing.T) {
 	tests := map[string]struct {
-		input []interface{}
-		want  int
+		input [][]byte
+		want  []byte
 	}{
-		"length of one": {input: []interface{}{1}, want: 1},
-		"length of two": {input: []interface{}{1, 2}, want: 1},
+		"length of one": {input: [][]byte{toHash(1)}, want: toHash(1)},
+		"length of two": {input: [][]byte{toHash(1), toHash(2)}, want: toHash(1)},
 	}
 
 	for name, test := range tests {
-		iter := Iterator{Items: test.input}
-		got := iter.next()
-		if got != test.want {
+		iter := merklego_mmr.Iterator{Items: test.input}
+		got := iter.Next()
+		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("%s: expected %v  got %v", name, test.want, got)
 		}
 	}
 
 	tests = map[string]struct {
-		input []interface{}
-		want  int
+		input [][]byte
+		want  []byte
 	}{
-		"call next twice": {input: []interface{}{1, 2}, want: 2},
+		"length of two": {input: [][]byte{toHash(1), toHash(2)}, want: toHash(2)},
 	}
 
 	for name, test := range tests {
-		iter := Iterator{Items: test.input}
-		_ = iter.next()
-		got := iter.next()
-		if got != test.want {
+		iter := merklego_mmr.Iterator{Items: test.input}
+		_ = iter.Next()
+		got := iter.Next()
+		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("%s: expected %v  got %v", name, test.want, got)
 		}
 	}

--- a/mmr/log.go
+++ b/mmr/log.go
@@ -7,6 +7,8 @@ type logger interface {
 
 var log logger
 
+// UseLogger takes any type that satisfies the logger interface as a argument. It the sets the global log variable to the
+// the value passed as an argument.
 func UseLogger(l logger) {
 	log = l
 }

--- a/mmr/mmr_store.go
+++ b/mmr/mmr_store.go
@@ -1,20 +1,24 @@
 package mmr
 
+// Store defines the required method on any store passed to the Batch struct
 type Store interface {
-	getElem(pos uint64) interface{}
-	append(pos uint64, elems []interface{})
+	getElem(pos uint64) []byte
+	append(pos uint64, elems [][]byte)
 }
 
+// BatchElem holds the fields of data for a Batch Element
 type BatchElem struct {
 	pos   uint64
-	elems []interface{}
+	elems [][]byte
 }
 
+// Batch contains the a slice of Batch elements and a Store
 type Batch struct {
 	memoryBatch []BatchElem
 	store       Store
 }
 
+// NewBatch returns an object of the Batch type
 func NewBatch(store Store) *Batch {
 	return &Batch{
 		memoryBatch: []BatchElem{},
@@ -22,11 +26,11 @@ func NewBatch(store Store) *Batch {
 	}
 }
 
-func (b *Batch) append(pos uint64, elems []interface{}) {
+func (b *Batch) append(pos uint64, elems [][]byte) {
 	b.memoryBatch = append(b.memoryBatch, BatchElem{pos, elems})
 }
 
-func (b *Batch) getElem(pos uint64) interface{} {
+func (b *Batch) getElem(pos uint64) []byte {
 	memoryBatch := make([]BatchElem, len(b.memoryBatch))
 	copy(memoryBatch, b.memoryBatch)
 	reverse(memoryBatch)

--- a/mmr/types.go
+++ b/mmr/types.go
@@ -1,13 +1,15 @@
 package mmr
 
+// Leaf is an mmr leaf. It also holds the field Leaf which is a byte representation of the leaf and Pos, the leaf
+// position.
 type Leaf struct {
 	Pos  uint64
-	Leaf interface{}
+	Leaf []byte
 }
 
 type leafWithHash struct {
 	pos    uint64
-	hash   interface{}
+	hash   []byte
 	height uint32
 }
 

--- a/mmr/util.go
+++ b/mmr/util.go
@@ -4,27 +4,32 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
-type MemStore map[uint64]interface{}
+// MemStore is a map of bytes with uint64 values as its key
+type MemStore map[uint64][]byte
 
+// NewMemStore creates an returns a map of the MemStore type
 func NewMemStore() MemStore {
-	return make(MemStore, 0)
+	return make(MemStore)
 }
 
-func (m MemStore) append(pos uint64, elem []interface{}) {
+func (m MemStore) append(pos uint64, elem [][]byte) {
 	for index, value := range elem {
 		m[pos+uint64(index)] = value
 	}
 }
 
-func (m MemStore) getElem(pos uint64) interface{} {
+func (m MemStore) getElem(pos uint64) []byte {
 	return m[pos]
 }
 
+// MemMMR is MMR implementation that uses a memory store. It has the fields store which takes the MemStore as an argument
+// and the mmrSize of the tree.
 type MemMMR struct {
 	store   MemStore
 	mmrSize uint64
 }
 
+// NewMemMMR returns an object of the MemMMR type. It takes in the mmrSize and Memory Store (MemStore) as arguments.
 func NewMemMMR(mmrSize uint64, store MemStore) *MemMMR {
 	return &MemMMR{
 		mmrSize: mmrSize,
@@ -32,36 +37,43 @@ func NewMemMMR(mmrSize uint64, store MemStore) *MemMMR {
 	}
 }
 
+// Store returns the MemStore
 func (m *MemMMR) Store() MemStore {
 	return m.store
 }
 
+// GetRoot returns the root of the MMR tree
 func (m *MemMMR) GetRoot() (interface{}, error) {
 	merge := &Merge{}
 	mmr := NewMMR(m.mmrSize, m.store, merge)
 	return mmr.GetRoot()
 }
 
-func (m *MemMMR) Push(elem interface{}) interface{} {
+// Push adds an element to the store and returns the position of the element
+func (m *MemMMR) Push(elem []byte) uint64 {
 	merge := &Merge{}
 	mmr := NewMMR(m.mmrSize, m.store, merge)
 	pos, err := mmr.Push(elem)
 	if err != nil {
 		log.Error(err.Error())
-		return nil
+		return 0
 	}
 	mmr.Commit()
 	return pos
 }
 
+// GenProof generates proofs for validating an MMR leaf
 func (m *MemMMR) GenProof(posList []uint64) (*MerkleProof, error) {
 	merge := &Merge{}
 	mmr := NewMMR(m.mmrSize, m.store, merge)
 	return mmr.GenProof(posList)
 }
 
+// Merge is an empty struct that satisfies the Merge interface by implementing the Merge method.
 type Merge struct{}
 
+// Merge takes two arguments of type []byte, appends both into a single byte slice, hashes the result using blake2b
+// and returns the resultant hash.
 func (m *Merge) Merge(left, right interface{}) interface{} {
 	l := left.([]byte)
 	r := right.([]byte)


### PR DESCRIPTION
* rename hash field in Leaf struct to Leaf
* remove return parameter from commit method
* return uint64 type from Push method instead of an interface
* resolve lint recommendations from pre-commit command
